### PR TITLE
feat: add api layer delegating to store

### DIFF
--- a/app/api.js
+++ b/app/api.js
@@ -1,0 +1,20 @@
+import Store from './store';
+
+// TODO: Replace Store calls with real REST/GraphQL requests when backend is available.
+export function getGoal(id) {
+  return Store.getGoal(id);
+}
+
+export function listGoals(ownerId) {
+  return Store.listGoals(ownerId);
+}
+
+export function listCycles() {
+  return Store.listCycles();
+}
+
+export default {
+  getGoal,
+  listGoals,
+  listCycles
+};

--- a/app/store.js
+++ b/app/store.js
@@ -1,0 +1,28 @@
+const goals = [
+  { id: 1, ownerId: 1, title: 'Learn React' },
+  { id: 2, ownerId: 1, title: 'Build an app' },
+  { id: 3, ownerId: 2, title: 'Write documentation' }
+];
+
+const cycles = [
+  { id: 1, name: 'Cycle 1' },
+  { id: 2, name: 'Cycle 2' }
+];
+
+export function getGoal(id) {
+  return goals.find(g => g.id === id) || null;
+}
+
+export function listGoals(ownerId) {
+  return goals.filter(g => g.ownerId === ownerId);
+}
+
+export function listCycles() {
+  return cycles;
+}
+
+export default {
+  getGoal,
+  listGoals,
+  listCycles
+};

--- a/components/GoalList.js
+++ b/components/GoalList.js
@@ -1,0 +1,18 @@
+import React, { useEffect, useState } from 'react';
+import api from '../app/api';
+
+export default function GoalList({ ownerId }) {
+  const [goals, setGoals] = useState([]);
+
+  useEffect(() => {
+    setGoals(api.listGoals(ownerId));
+  }, [ownerId]);
+
+  return (
+    <ul>
+      {goals.map(goal => (
+        <li key={goal.id}>{goal.title}</li>
+      ))}
+    </ul>
+  );
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import GoalList from '../components/GoalList';
+
+export default function HomePage() {
+  return <GoalList ownerId={1} />;
+}


### PR DESCRIPTION
## Summary
- add api module exposing domain methods and delegating to Store
- update components and pages to use api instead of store
- note future replacement with real REST/GraphQL calls

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a210726eac832ea926665f33b15599