### PR TITLE
Add role-based navigation check and tests

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -1,0 +1,26 @@
+let currentRoles = [];
+
+function setUserRoles(roles) {
+  currentRoles = roles;
+}
+
+function requireRole(role) {
+  if (!role) return true;
+  return currentRoles.includes(role);
+}
+
+const routes = {
+  '#/login': {},
+  '#/admin': { role: 'admin' },
+  '#/home': {}
+};
+
+function navigate(hash) {
+  const route = routes[hash];
+  if (route && !requireRole(route.role)) {
+    return '#/login';
+  }
+  return hash;
+}
+
+module.exports = { navigate, setUserRoles, requireRole, routes };

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "kaskada",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "node test/router.test.js"
+  }
+}

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -1,0 +1,10 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+const { navigate, setUserRoles } = require('../app/router');
+
+test('redirects to login when user lacks admin role', () => {
+  setUserRoles([]); // user without admin role
+  const result = navigate('#/admin');
+  assert.strictEqual(result, '#/login');
+});


### PR DESCRIPTION
## Summary
- add `requireRole` helper and enforce login redirect when roles mismatch
- cover admin access denial with node:test scenario

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2107165a4832e9ae25e715f00f185